### PR TITLE
v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 0.1.1
+
+- Bump `event-listener` to v5.1.0. (#3)
+
 # Version 0.1.0
 
 - Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smol-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.63"
 authors = ["John Nunley <dev@notgull.net>"]


### PR DESCRIPTION
- Bump `event-listener` to v5.1.0. (#3)
