### PR TITLE
tests: Replace unsend with async-lock for LocalExecutor barrier tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,3 @@ futures-lite = { version = "2.0.1", default-features = false }
 [dev-dependencies]
 async-lock = "3.1.2"
 macro_rules_attribute = "0.2.0"
-unsend = { version = "0.2.1", default-features = false, features = ["alloc"] }

--- a/tests/macro_usages.rs
+++ b/tests/macro_usages.rs
@@ -79,7 +79,7 @@ async fn with_executor_arcref(ex: &Arc<Executor<'static>>) {
 
 #[apply(test!)]
 async fn with_local(ex: &LocalExecutor<'_>) {
-    let barrier = Rc::new(unsend::lock::Barrier::new(2));
+    let barrier = Rc::new(async_lock::Barrier::new(2));
     ex.spawn({
         let barrier = barrier.clone();
         async move {
@@ -98,7 +98,7 @@ async fn with_local(ex: &LocalExecutor<'_>) {
 
 #[apply(test!)]
 async fn with_local_rc(ex: Rc<LocalExecutor<'_>>) {
-    let barrier = Rc::new(unsend::lock::Barrier::new(2));
+    let barrier = Rc::new(async_lock::Barrier::new(2));
     ex.spawn({
         let barrier = barrier.clone();
         async move {
@@ -117,7 +117,7 @@ async fn with_local_rc(ex: Rc<LocalExecutor<'_>>) {
 
 #[apply(test!)]
 async fn with_local_rcref(ex: &Rc<LocalExecutor<'_>>) {
-    let barrier = Rc::new(unsend::lock::Barrier::new(2));
+    let barrier = Rc::new(async_lock::Barrier::new(2));
     ex.spawn({
         let barrier = barrier.clone();
         async move {


### PR DESCRIPTION
The unsend crate uses the Patron license which is not a free-software license. This is an issue when packaging for Fedora. However looking at the usage, it is only used for a barrier.

So lets replace unsend::lock::Barrier with async_lock::Barrier (already a dev-dependency).